### PR TITLE
Add option to rotate pawn based on target point rotation

### DIFF
--- a/DaedalicTestAutomationPlugin/Source/DaedalicTestAutomationPlugin/Public/DaeTestPerformanceBudgetActor.h
+++ b/DaedalicTestAutomationPlugin/Source/DaedalicTestAutomationPlugin/Public/DaeTestPerformanceBudgetActor.h
@@ -39,6 +39,11 @@ private:
     UPROPERTY(EditAnywhere)
     TSubclassOf<APawn> PawnClass;
 
+    /** Interpolates pawn rotation between current/next target point rotation when true
+        otherwise pawn faces the direction of movement */
+    UPROPERTY(EditAnywhere)
+    bool bUseTargetRotation;
+
     /** How long to wait before starting to fly, in seconds. */
     UPROPERTY(EditAnywhere)
     float InitialDelay;


### PR DESCRIPTION
I needed a way to control the gaze of the camera more deliberately to focus on areas of concern during performance tests. This pull request was the most straight forward way to do this. It uses the rotation of the previous and next point and lerps the pawn's rotation based on completion of the current segment.

This makes it as easy as changing the rotation of target points to control where the camera is pointing.