### PR TITLE
Allow all PIE clients to run multiplayer tests

### DIFF
--- a/DaedalicTestAutomationPlugin/Source/DaedalicTestAutomationPlugin/Private/DaeTestSuiteActor.cpp
+++ b/DaedalicTestAutomationPlugin/Source/DaedalicTestAutomationPlugin/Private/DaeTestSuiteActor.cpp
@@ -34,7 +34,8 @@ void ADaeTestSuiteActor::Tick(float DeltaSeconds)
     {
         // Check if we should run all tests immediately.
         // Happening in first Tick to make sure all actors have begun play.
-        if (bRunInPIE && GetWorld()->IsPlayInEditor() && TestIndex < 0)
+        // When launching multiple clients in 1 map, world type for non-editor client is IsPlayInPreview()
+        if (bRunInPIE && (GetWorld()->IsPlayInEditor() || GetWorld()->IsPlayInPreview()) && TestIndex < 0)
         {
             RunAllTests();
         }


### PR DESCRIPTION
When running multiple clients in the editor, the first client will take over the main PIE window while the remaining clients will open their own game window. The clients that open their own game window would not run tests before this fix.