### PR TITLE
migrated automation script to dot net core for ue5

### DIFF
--- a/DaedalicTestAutomationPlugin.Automation/DaedalicTestAutomationPlugin.Automation.csproj
+++ b/DaedalicTestAutomationPlugin.Automation/DaedalicTestAutomationPlugin.Automation.csproj
@@ -1,55 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C008207C-E5DF-41F3-B0ED-6A1A80F7234B}</ProjectGuid>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DaedalicTestAutomationPlugin.Automation</RootNamespace>
-    <AssemblyName>DaedalicTestAutomationPlugin.Automation</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <Configurations>Debug;Release;Development</Configurations>	
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>$(UNREAL_ENGINE_4_PATH)\Engine\Binaries\DotNET\AutomationScripts\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <OutputPath>..\..\..\..\Binaries\DotNET\AutomationScripts\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Development|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>$(UNREAL_ENGINE_4_PATH)\Engine\Binaries\DotNET\AutomationScripts\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <OutputPath>..\..\..\..\Binaries\DotNET\AutomationScripts\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DaeGauntletTest.cs" />
-    <Compile Include="DaeTestConfig.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <ProjectReference Include="..\..\..\..\Engine\Source\Programs\AutomationTool\Gauntlet\Gauntlet.Automation.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(UNREAL_ENGINE_4_PATH)\Engine\Source\Programs\AutomationTool\Gauntlet\Gauntlet.Automation.csproj">
-      <Project>{767B4F85-AB56-4B00-A033-04C7600ACC3D}</Project>
-      <Name>Gauntlet.Automation</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Process used for this migration:
* Ran https://github.com/dotnet/try-convert
* Hand edited to change `TargetFramework ` to netcoreapp3.1
* Hand edited to add `Configurations` block
* Changed paths to relative, removing references to UE4

Project now loads & builds, creates expected DaedalicTestAutomationPlugin.Automation.* alongside EpicGames.Build.* etc in `(project root)\Binaries\DotNET\AutomationScripts\netcoreapp3.1`

This PR targets the 5.0 branch, the change is not backwards compatible with UE4.2, I dont think there is a way to do that without having who versions of the automation in the git repo and having users copy the correct version into their project.

This PR closes issues #38 + #34 